### PR TITLE
add instructions and dockerized setup for local dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim-buster
+
+WORKDIR /app
+
+RUN apt-get update && \
+    apt-get install -y entr && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir \
+    sphinx \
+    sphinx_rtd_theme \
+    myst_parser
+
+CMD find doc -type f | entr -r sh -c \
+    'sphinx-build doc _build && python -m http.server 8000 --directory _build'

--- a/README.md
+++ b/README.md
@@ -2,3 +2,26 @@
 
 We use this example in the lesson
 [How to document your research software](https://coderefinery.github.io/documentation/).
+
+## Host the project for local development
+Generating the documentation pages is based on [sphinx](https://www.sphinx-doc.org/en/master/) and the [sphinx_rtd_theme](https://sphinx-rtd-theme.readthedocs.io/en/stable/).
+
+### Docker
+For convenience, a [docker](https://www.docker.com/)-based setup is provided here. To get started, simply run:
+```bash
+docker compose up
+```
+after which the documentation pages will be hosted *with hot reload* on 127.0.0.1:8000
+
+### Python
+The following [PyPI](https://pypi.org/) packages are required:
+- [Sphinx](https://pypi.org/project/Sphinx/)
+- [sphinx_rtd_theme](https://pypi.org/project/sphinx-rtd-theme/)
+- [myst_parser](https://pypi.org/project/myst_parser/)
+
+When these are installed in your environment, you can run:
+```bash
+sphinx-build doc _build
+python -m http.server 8000 --directory _build
+```
+after which the documentation pages will be hosted on 127.0.0.1:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+
+services:
+  docs:
+    build: .
+    volumes:
+      - .:/app
+    ports:
+      - 8000:8000


### PR DESCRIPTION
This PR provides a simple one-command docker setup to generate and host the documentation pages locally. 